### PR TITLE
Fixes disconnect android

### DIFF
--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/screens/UnlockScreenActivity.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/screens/UnlockScreenActivity.java
@@ -25,7 +25,7 @@ import static com.hoxfon.react.RNTwilioVoice.TwilioVoiceModule.ACTION_REJECTED_C
 
 public class UnlockScreenActivity extends ReactActivity {
 
-  public static String TAG = "RNTwilioVoice";
+  public static String TAG = "RNTwilioVoice.unlockScreenActivity";
   private UnlockScreenActivity.UnlockScreenBroadcastReceiver unlockScreenBroadcastReceiver;
   private boolean isReceiverRegistered = false;
 
@@ -44,6 +44,7 @@ public class UnlockScreenActivity extends ReactActivity {
 
     final ReactContext reactContext = getReactInstanceManager().getCurrentReactContext();
     unlockScreenBroadcastReceiver = new UnlockScreenActivity.UnlockScreenBroadcastReceiver();
+    Log.d(TAG, "Register Receiver ");
     registerReceiver();
 
     Button acceptCallBtn = (Button) findViewById(R.id.accept_call_btn);
@@ -69,11 +70,6 @@ public class UnlockScreenActivity extends ReactActivity {
 
   @Override protected void onPause() {
     super.onPause();
-    if (isReceiverRegistered) {
-      LocalBroadcastManager.getInstance(
-          getReactInstanceManager().getCurrentReactContext()
-      ).unregisterReceiver(unlockScreenBroadcastReceiver);
-    }
   }
 
   private class UnlockScreenBroadcastReceiver extends BroadcastReceiver {

--- a/android/src/main/java/com/hoxfon/react/RNTwilioVoice/screens/UnlockScreenActivity.java
+++ b/android/src/main/java/com/hoxfon/react/RNTwilioVoice/screens/UnlockScreenActivity.java
@@ -68,8 +68,14 @@ public class UnlockScreenActivity extends ReactActivity {
     });
   }
 
-  @Override protected void onPause() {
-    super.onPause();
+  @Override protected void onDestroy() {
+    super.onDestroy();
+
+    if (isReceiverRegistered) {
+      LocalBroadcastManager.getInstance(
+          getReactInstanceManager().getCurrentReactContext()
+      ).unregisterReceiver(unlockScreenBroadcastReceiver);
+    }
   }
 
   private class UnlockScreenBroadcastReceiver extends BroadcastReceiver {


### PR DESCRIPTION
The unlock screen failed to listen to the disconnect event since it was being unregistered on activity pause.
This PR moves the unregistration to the onDestroy listener, since the screen adds the listener on every create.